### PR TITLE
Python3 support + small fixes and circular dependency resolving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *gfffeature.so
 *.swp
 *.pyc
+.idea
 gffutils.egg-info/
 .coverage
 doc/build/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
     - "2.7"
+    - "3.3"
 
 install:
     - "pip install -r requirements.txt"

--- a/gffutils/__init__.py
+++ b/gffutils/__init__.py
@@ -1,6 +1,8 @@
-from create import create_db
-from interface import FeatureDB
-from feature import Feature
-from iterators import FileIterator, UrlIterator, StringIterator, FeatureIterator
-from helpers import example_filename, FeatureNotFoundError, DuplicateIDError
-from version import version as __version__
+from gffutils.create import create_db
+from gffutils.interface import FeatureDB
+from gffutils.feature import Feature
+from gffutils.iterators import (FileIterator, UrlIterator, StringIterator,
+                                FeatureIterator)
+from gffutils.helpers import example_filename
+from gffutils.exceptions import FeatureNotFoundError, DuplicateIDError
+from gffutils.version import version as __version__

--- a/gffutils/attributes.py
+++ b/gffutils/attributes.py
@@ -1,0 +1,105 @@
+import six
+import collections
+from gffutils import constants
+
+# collections.MutableMapping is apparently the best way to provide dict-like
+# interface (http://stackoverflow.com/a/3387975)
+class Attributes(collections.MutableMapping):
+    def __init__(self, *args, **kwargs):
+        """
+        An Attributes object acts much like a dictionary.  However, values are
+        always stored internally as lists, even if a single value is provided.
+
+        Whether or not you get a list back depends on the
+        `constants.always_return_list` setting, which can be set on-the-fly.
+        If True, then one-item lists are returned.  This is best shown with an
+        example:
+
+        Set up an Attributes object:
+
+            >>> attr = Attributes()
+
+        Set the "Name" attribute with a string:
+
+            >>> attr['Name'] = 'gene1'
+
+        This is stored internally as a list, and by default, we'll get a list
+        back:
+
+            >>> assert attr['Name'] == ['gene1']
+
+        The same thing happens if we set it with a list in the first place:
+
+            >>> attr['Name'] = ['gene1']
+            >>> assert attr['Name'] == ['gene1']
+
+        Now, change the setting so that upon access, single-value lists are
+        returned as the first item.
+
+            >>> constants.always_return_list = False
+            >>> assert attr['Name'] == 'gene1'
+
+        Change it back again:
+
+            >>> constants.always_return_list = True
+            >>> assert attr['Name'] == ['gene1']
+
+        """
+        self._d = dict()
+        self.update(*args, **kwargs)
+
+    def __setitem__(self, k, v):
+        if not isinstance(v, (list, tuple)):
+            v = [v]
+        self._d[k] = v
+
+    def __getitem__(self, k):
+        v = self._d[k]
+        if constants.always_return_list:
+            return v
+        if isinstance(v, list) and len(v) == 1:
+            v = v[0]
+        return v
+
+    def __delitem__(self, key):
+        del self._d[key]
+
+    def __iter__(self):
+        return iter(self.keys)
+
+    def __len__(self):
+        return len(self._d)
+
+    def keys(self):
+        return self._d.keys()
+
+    def values(self):
+        return [self.__getitem__(k) for k in self.keys()]
+
+    def items(self):
+        r = []
+        for k in self.keys():
+            r.append((k, self.__getitem__(k)))
+        return r
+
+    def __str__(self):
+        s = []
+        for i in self.items():
+            s.append("%s: %s" % i)
+        return '\n'.join(s)
+
+    def update(self, *args, **kwargs):
+        for k, v in six.iteritems(dict(*args, **kwargs)):
+            self[k] = v
+
+
+
+# Useful for profiling: which dictionary-like class to store attributes in.
+# This is used in Feature below and in parser.py
+
+dict_class = Attributes
+#dict_class = dict
+#dict_class = helper_classes.DefaultOrderedDict
+#dict_class = collections.defaultdict
+#dict_class = collections.OrderedDict
+#dict_class = helper_classes.DefaultListOrderedDict

--- a/gffutils/bins.py
+++ b/gffutils/bins.py
@@ -92,7 +92,7 @@ def bins(start, stop, fmt='gff', one=True):
                 return offset + start
 
         # See the Fig 7 reproduction above to see why range().
-        bins.update(range(offset + start, offset + stop + 1))
+        bins.update(list(range(offset + start, offset + stop + 1)))
 
         # Move to the next level (8x larger bin size; i.e., 2**NEXT_SHIFT
         # larger bin size)
@@ -124,8 +124,8 @@ def print_bin_sizes():
         size = '(%s %s)' % (bin_size, suffix)
         actual_size = '%s bp' % (actual_size)
 
-        print 'level: {i:1};  bins {binstart:<4} to {binstop:<4}; '\
-              'size: {actual_size:<12} {size:<6}'.format(**locals())
+        print('level: {i:1};  bins {binstart:<4} to {binstop:<4}; '
+              'size: {actual_size:<12} {size:<6}'.format(**locals()))
 
 
 def test():

--- a/gffutils/convert.py
+++ b/gffutils/convert.py
@@ -2,6 +2,9 @@
 Conversion functions that operate on :class:`FeatureDB` classes.
 """
 
+import six
+
+
 def to_bed12(f, db, child_type='exon', name_field='ID'):
     """
     Given a top-level feature (e.g., transcript), construct a BED12 entry
@@ -22,7 +25,7 @@ def to_bed12(f, db, child_type='exon', name_field='ID'):
         Attribute to be used in the "name" field of the BED12 entry.  Usually
         "ID" for GFF; "transcript_id" for GTF.
     """
-    if isinstance(f, basestring):
+    if isinstance(f, six.string_types):
         f = db[f]
     children = list(db.children(f, featuretype=child_type, order_by='start'))
     sizes = [len(i) for i in children]

--- a/gffutils/create.py
+++ b/gffutils/create.py
@@ -1,19 +1,18 @@
 import copy
 import warnings
-from textwrap import dedent
 import collections
 import tempfile
 import sys
 import os
 import sqlite3
-import constants
-import version
-import parser
-import bins
-import helpers
-import feature
-import interface
-import iterators
+import six
+from gffutils import constants
+from gffutils import version
+from gffutils import bins
+from gffutils import helpers
+from gffutils import feature
+from gffutils import interface
+from gffutils import iterators
 
 import logging
 
@@ -60,7 +59,7 @@ class _DBCreator(object):
                 os.unlink(dbfn)
         self.dbfn = dbfn
         self.id_spec = id_spec
-        if isinstance(dbfn, basestring):
+        if isinstance(dbfn, six.string_types):
             conn = sqlite3.connect(dbfn)
         else:
             conn = dbfn
@@ -103,7 +102,7 @@ class _DBCreator(object):
         """
 
         # If id_spec is a string, convert to iterable for later
-        if isinstance(self.id_spec, basestring):
+        if isinstance(self.id_spec, six.string_types):
             id_key = [self.id_spec]
 
         elif hasattr(self.id_spec, '__call__'):
@@ -114,7 +113,7 @@ class _DBCreator(object):
         elif isinstance(self.id_spec, dict):
             try:
                 id_key = self.id_spec[f.featuretype]
-                if isinstance(id_key, basestring):
+                if isinstance(id_key, six.string_types):
                     id_key = [id_key]
 
             # Otherwise, use default auto-increment.
@@ -409,7 +408,7 @@ class _DBCreator(object):
         c.executemany(
             '''
             INSERT OR REPLACE INTO autoincrements VALUES (?, ?)
-            ''', self._autoincrements.items())
+            ''', list(self._autoincrements.items()))
 
         # These indexes are *well* worth the effort and extra storage: over
         # 500x speedup on code like this:
@@ -454,8 +453,8 @@ class _DBCreator(object):
         Execute a query directly on the database.
         """
         c = self.conn.cursor()
-        c.execute(query)
-        for i in cursor:
+        result = c.execute(query)
+        for i in result:
             yield i
 
     def _insert(self, feature, cursor):
@@ -834,7 +833,7 @@ class _GTFDBCreator(_DBCreator):
             keys = ['parent', 'seqid', 'start', 'end', 'strand',
                     'featuretype', 'bin', 'attributes']
             for line in open(fout.name):
-                d = dict(zip(keys, line.strip().split('\t')))
+                d = dict(list(zip(keys, line.strip().split('\t'))))
                 d.pop('parent')
                 d['score'] = '.'
                 d['source'] = 'gffutils_derived'

--- a/gffutils/exceptions.py
+++ b/gffutils/exceptions.py
@@ -1,0 +1,19 @@
+class FeatureNotFoundError(Exception):
+    """
+    Error to be raised when an ID is not in the database.
+    """
+    def __init__(self, feature_id):
+        Exception.__init__(self)
+        self.feature_id = feature_id
+
+    def __str__(self):
+        return self.feature_id
+
+
+class DuplicateIDError(Exception):
+    pass
+
+
+class AttributeStringError(Exception):
+    pass
+

--- a/gffutils/gffwriter.py
+++ b/gffutils/gffwriter.py
@@ -1,11 +1,11 @@
 ##
 ## GFF Writer (writer): serializing gffutils records as GFF text files.
 ##
-import time
+import six
 import tempfile
 import shutil
 from time import strftime, localtime
-from version import version
+from gffutils.version import version
 
 
 class GFFWriter:
@@ -40,7 +40,7 @@ class GFFWriter:
         self.temp_file = None
         # Output stream to write to
         self.out_stream = None
-        if isinstance(out, basestring):
+        if isinstance(out, six.string_types):
             if self.in_place:
                 # Use temporary file
                 self.temp_file = tempfile.NamedTemporaryFile(delete=False)

--- a/gffutils/parser.py
+++ b/gffutils/parser.py
@@ -1,13 +1,9 @@
 # Portions copied over from BCBio.GFF.GFFParser
 
 import re
-import urllib
 import copy
-import constants
-from helpers import example_filename
-import helpers
-import bins
-import feature
+from gffutils import constants
+from gffutils.exceptions import AttributeStringError
 
 import logging
 
@@ -40,7 +36,7 @@ def _reconstruct(keyvals, dialect, keep_order=False):
         False, which saves time especially on large data sets.
     """
     if not dialect:
-        raise helpers.AttributeStringError
+        raise AttributeStringError()
     if not keyvals:
         return ""
     parts = []
@@ -55,7 +51,7 @@ def _reconstruct(keyvals, dialect, keep_order=False):
             else:
                 items.append((key, val))
     else:
-        items = keyvals.items()
+        items = list(keyvals.items())
 
     def sort_key(x):
         # sort keys by their order in the dialect; anything not in there will
@@ -117,7 +113,7 @@ def _split_keyvals(keyval_str, dialect=None):
         # Make a copy of default dialect so it can be modified as needed
         dialect = copy.copy(constants.dialect)
         infer_dialect = True
-
+    from gffutils import feature
     quals = feature.dict_class()
     if not keyval_str:
         return quals, dialect
@@ -237,7 +233,7 @@ def _split_keyvals(keyval_str, dialect=None):
             quals[key] = []
 
         # Remove quotes in GFF2
-        if (len(val) > 0 and val[0] == '"' and val[-1] == '"'):
+        if len(val) > 0 and val[0] == '"' and val[-1] == '"':
             val = val[1:-1]
             dialect['quoted GFF2 values'] = True
         if val:
@@ -246,7 +242,7 @@ def _split_keyvals(keyval_str, dialect=None):
             # quals[key].extend([v for v in val.split(',') if v])
             vals = val.split(',')
             if (len(vals) > 1) and dialect['repeated keys']:
-                raise helpers.AttributeStringError(
+                raise AttributeStringError(
                     "Internally inconsistent attributes formatting: "
                     "some have repeated keys, some do not.")
             quals[key].extend(vals)

--- a/gffutils/scripts/gffutils-cli
+++ b/gffutils/scripts/gffutils-cli
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function
+
 """
 Command line interface for gffutils.
 
@@ -17,6 +19,7 @@ you'll get the cli for free.
 import os
 import gffutils
 import gffutils.helpers as helpers
+from gffutils.exceptions import FeatureNotFoundError
 import gffutils.gffwriter as gffwriter
 import argh
 from argcomplete.completers import EnvironCompleter
@@ -60,8 +63,8 @@ def fetch(db, ids):
     for i in ids.split(','):
         try:
             yield gff_db[i]
-        except helpers.FeatureNotFoundError:
-            print >> sys.stderr, "%s not found" %(i)
+        except FeatureNotFoundError:
+            print ("%s not found" % i, file=sys.stderr)
 
 
 # children subcommand ---------------------------------------------------------
@@ -205,12 +208,12 @@ def sanitize(filename,
 
     Outputs result to stdout unless asked to sanitize in place.
     """
-    print >> sys.stderr, "Sanitizing GFF %s" %(filename)
+    print("Sanitizing GFF %s" % filename, file=sys.stderr)
     if in_memory:
-        print >> sys.stderr, "  - Loading GFF in memory"
+        print("  - Loading GFF in memory", file=sys.stderr)
     if in_place:
-        print >> sys.stderr, "  - Sanitizing file in place " \
-                             "(overwriting current file)"
+        print("  - Sanitizing file in place (overwriting current file)",
+              file=sys.stderr)
     helpers.sanitize_gff_file(filename,
                               in_memory=in_memory,
                               in_place=in_place)
@@ -222,7 +225,7 @@ def rmdups(filename, in_place=False):
     """
     Remove duplicates from a GFF file. 
     """
-    print "Removing duplicates from: %s" %(filename)
+    print("Removing duplicates from: %s" % filename)
     merge_strategy = "merge"
     if not in_place:
         # Write to stdout

--- a/gffutils/test/feature_test.py
+++ b/gffutils/test/feature_test.py
@@ -92,8 +92,8 @@ def test_hash():
 def test_repr():
     line = "chr2L	FlyBase	exon	7529	8116	.	+	.	Name=CG11023:1;Parent=FBtr0300689,FBtr0300690	some	more	stuff"
     f = feature.feature_from_line(line)
-    print repr(f)
-    print hex(id(f))
+    print(repr(f))
+    print(hex(id(f)))
     assert repr(f) == ("<Feature exon (chr2L:7529-8116[+]) at %s>" % hex(id(f)))
 
 def test_attribute_order():

--- a/gffutils/test/from-prev-version
+++ b/gffutils/test/from-prev-version
@@ -176,8 +176,8 @@ def test_inspect_featuretypes():
     observed = gffutils.inspect_featuretypes(gffutils.example_filename('FBgn0031208.gff'))
     observed.sort()
     expected = ['CDS', 'exon', 'five_prime_UTR', 'gene', 'intron', 'mRNA', 'pcr_product', 'protein', 'three_prime_UTR']
-    print observed
-    print expected
+    print(observed)
+    print(expected)
     assert observed == expected
 
 class GenericDBClass(object):
@@ -208,15 +208,15 @@ class GenericDBClass(object):
         self.c.execute('select name from sqlite_master where type="table"')
         observed_tables = [str(i[0]) for i in self.c]
         observed_tables.sort()
-        print expected_tables
-        print observed_tables
+        print(expected_tables)
+        print(observed_tables)
         assert expected_tables == observed_tables
 
     def _count1(self,featuretype):
         # Count using SQL
         self.c.execute('select count() from features where feature = ?',(featuretype,))
         results = self.c.fetchone()[0]
-        print 'count1("%s") says: %s' % (featuretype,results)
+        print('count1("%s") says: %s' % (featuretype,results))
         return results
 
     def _count2(self,featuretype):
@@ -232,13 +232,13 @@ class GenericDBClass(object):
 
             if L[2] == featuretype:
                 cnt += 1
-        print 'count2("%s") says: %s' % (featuretype, cnt)
+        print('count2("%s") says: %s' % (featuretype, cnt))
         return cnt
 
     def _count3(self,featuretype):
         # Count with the count_features_of_type method.
         results = self.G.count_features_of_type(featuretype)
-        print 'count3("%s") says: %s' % (featuretype, results)
+        print('count3("%s") says: %s' % (featuretype, results))
         return results
 
     def _count4(self,featuretype):
@@ -246,7 +246,7 @@ class GenericDBClass(object):
         cnt = 0
         for i in self.G.features_of_type(featuretype):
             cnt += 1
-        print 'count4("%s") says: %s' % (featuretype,cnt)
+        print('count4("%s") says: %s' % (featuretype,cnt))
         return cnt
 
     def featurecount_test(self):
@@ -277,7 +277,7 @@ class GenericDBClass(object):
                 assert rawsql_cnt == count_feature_of_type_cnt == iterator_cnt == gffparsed_cnt == hard_count
 
             if self.featureclass == 'GTF':
-                print 'hard count:',hard_count
+                print('hard count:',hard_count)
                 assert rawsql_cnt == count_feature_of_type_cnt == iterator_cnt == hard_count
 
     def total_features_test(self):
@@ -308,8 +308,8 @@ class GenericDBClass(object):
             parents2 = GTF_parent_check_level_2
         for child, expected_parents in parents1.items():
             observed_parents = [i.id for i in self.G.parents(child, level=1)]
-            print 'observed parents for %s:' % child, set(observed_parents)
-            print 'expected parents for %s:' % child, set(expected_parents)
+            print('observed parents for %s:' % child, set(observed_parents))
+            print('expected parents for %s:' % child, set(expected_parents))
             assert set(observed_parents) == set(expected_parents)
 
     def identity_test(self):
@@ -325,18 +325,18 @@ class GenericDBClass(object):
         first_feature = iterator.next()
         feature_string = first_feature.tostring()
 
-        print 'first line:',first_line
-        print 'first feat:',first_feature.tostring()
+        print('first line:',first_line)
+        print('first feat:',first_feature.tostring())
         assert feature_string == first_line
 
     def all_test(self):
         # all() returns expected number of features?
         results = list(self.G.all())
         if self.featureclass == 'GFF':
-            print len(results)
+            print(len(results))
             assert len(results) == 27
         if self.featureclass == 'GTF':
-            print len(results)
+            print(len(results))
 
             # 23 entries;
             #  3 genes, but 1 is noncoding
@@ -352,7 +352,7 @@ class GenericDBClass(object):
         d = expected_feature_counts[self.featureclass]
         for key,val in d.items():
             observed = len(list(self.G.features_of_type(key)))
-            print 'key:',"'"+key+"'",'val:',val,'observed:', observed
+            print('key:',"'"+key+"'",'val:',val,'observed:', observed)
             assert observed == val
 
         # now either catch all...
@@ -371,8 +371,8 @@ class GenericDBClass(object):
             observed = list(self.G.features_of_type(key, chrom='chr2L', strand='-', start=9999, stop=100000))
             expected_len = 2
             if key == 'gene' or key == 'mRNA':
-                print 'observed:',observed
-                print 'expected len:',expected_len
+                print('observed:',observed)
+                print('expected len:',expected_len)
                 assert len(observed) == expected_len
 
 
@@ -408,8 +408,8 @@ class GenericDBClass(object):
             if len(L) < 1:
                 continue
             gffchroms.append(L[0])
-        print 'observed:',set(self.G.chromosomes())
-        print 'expected:',set(gffchroms)
+        print('observed:',set(self.G.chromosomes()))
+        print('expected:',set(gffchroms))
         assert set(gffchroms) == set(self.G.chromosomes())
 
     def closest_features_test(self):
@@ -420,7 +420,7 @@ class GenericDBClass(object):
                                                                  pos=1,
                                                                  featuretype='gene',
                                                                  strand='+')
-        print observed_feature
+        print(observed_feature)
         assert observed_feature.id == 'FBgn0031208'
 
         # closest one to beginning, ignoring the first one.  Should return None.
@@ -429,7 +429,7 @@ class GenericDBClass(object):
                                         featuretype='gene',
                                         strand='+',
                                         ignore=['FBgn0031208'])
-        print result
+        print(result)
         assert result == (None,None)
 
         # should work the same with a string rather than list
@@ -438,7 +438,7 @@ class GenericDBClass(object):
                                         featuretype='gene',
                                         strand='+',
                                         ignore='FBgn0031208')
-        print result
+        print(result)
         assert result == (None,None)
 
         # closest mRNA to beginning, on - strand.
@@ -447,7 +447,7 @@ class GenericDBClass(object):
                                                                  featuretype='mRNA',
                                                                  strand='-',
                                                                  ignore=None,)
-        print observed_feature
+        print(observed_feature)
         assert observed_feature.id == 'transcript_Fk_gene_1'
 
         # TODO: the GFF/GTF files probably need some more genes added to be
@@ -463,7 +463,7 @@ class GenericDBClass(object):
         try:
             self.G['another fake one']
         except gffutils.FeatureNotFoundError as e:
-            print e
+            print(e)
             assert str(e) == 'another fake one'
 
     def getitem_and_eq_test(self):
@@ -493,19 +493,19 @@ chr2L	protein_coding	stop_codon	9277	9279	.	+	0	gene_id "FBgn0031208"; transcrip
 
         observed_string_1 = observed_feature_1.tostring()
 
-        #print 'expected :',expected
-        #print 'observed1:',observed_string_1
+        #print('expected :',expected)
+        #print('observed1:',observed_string_1)
 
         #d = difflib.ndiff(expected.splitlines(True), observed_string_1.splitlines(True))
-        #print ''.join(d)
-        print observed_string_1
+        #print(''.join(d))
+        print(observed_string_1)
         assert observed_string_1 == expected
 
         observed_feature_2 = self.G[observed_feature_1]
 
         observed_string_2 = observed_feature_2.tostring()
-        print 'expected :',expected
-        print 'observed2:',observed_string_2
+        print('expected :',expected)
+        print('observed2:',observed_string_2)
         assert observed_string_2 == expected
 
         assert str(observed_feature_1) == str(observed_feature_2)
@@ -513,7 +513,7 @@ chr2L	protein_coding	stop_codon	9277	9279	.	+	0	gene_id "FBgn0031208"; transcrip
     def overlapping_features_test(self):
         # test everything against a hard-coded list.
         observed = sorted([i.id for i in self.G.overlapping_features(chrom='chr2L', start=7529, stop=9484,completely_within=False)])
-        print observed
+        print(observed)
         if self.featureclass == 'GFF':
             expected_hardcoded = [
                              'CG11023:1',
@@ -554,8 +554,8 @@ chr2L	protein_coding	stop_codon	9277	9279	.	+	0	gene_id "FBgn0031208"; transcrip
                     'stop_codon:chr2L:8611-8613:+',
                     'stop_codon:chr2L:9277-9279:+']
 
-        print 'observed:',set(observed)
-        print 'expected:',set(expected_hardcoded)
+        print('observed:',set(observed))
+        print('expected:',set(expected_hardcoded))
         assert set(observed) == set(expected_hardcoded)
 
         # assert that features that overlap the gene contain the gene's children and grandchildren
@@ -570,14 +570,14 @@ chr2L	protein_coding	stop_codon	9277	9279	.	+	0	gene_id "FBgn0031208"; transcrip
         expected_generated += list(self.G.children('FBgn0031208',level=2,featuretype='intron'))
         expected_generated.append(self.G['FBgn0031208'])
         expected_generated = sorted([i.id for i in expected_generated])
-        print observed
-        print expected_generated
-        print set(observed).difference(expected_generated)
+        print(observed)
+        print(expected_generated)
+        print(set(observed).difference(expected_generated))
         assert observed == expected_generated
 
         # check that the first exon, which is chr2L:7529-8116, overlaps lots of stuff....
         observed = sorted([i.id for i in self.G.overlapping_features(chrom='chr2L',start=7529,stop=8116, completely_within=False, strand='+')])
-        print 'observed:',observed
+        print('observed:',observed)
         if self.featureclass == 'GFF':
             expected = ['CDS_FBgn0031208:1_737',
                         'CG11023:1',
@@ -596,7 +596,7 @@ chr2L	protein_coding	stop_codon	9277	9279	.	+	0	gene_id "FBgn0031208"; transcrip
                         'FBtr0300690',
                         'exon:chr2L:7529-8116:+',
                         'start_codon:chr2L:7680-7682:+']
-        print 'expected:',expected
+        print('expected:',expected)
         assert observed == expected
 
         # on the opposite strand, though, you should have nothing.
@@ -606,7 +606,7 @@ chr2L	protein_coding	stop_codon	9277	9279	.	+	0	gene_id "FBgn0031208"; transcrip
 
         # completely_within, however, should only return the UTR, exon, and CDS for GFF, (and exon, CDS, and start codon for GTF)
         observed = sorted([i.id for i in self.G.overlapping_features(chrom='chr2L',start=7529,stop=8116, completely_within=True)])
-        print 'observed:',observed
+        print('observed:',observed)
         if self.featureclass == 'GFF':
             expected = [
                         'CDS_FBgn0031208:1_737',
@@ -620,24 +620,24 @@ chr2L	protein_coding	stop_codon	9277	9279	.	+	0	gene_id "FBgn0031208"; transcrip
                     'CDS:chr2L:7680-8116:+',
                     'exon:chr2L:7529-8116:+',
                     'start_codon:chr2L:7680-7682:+']
-        print 'expected:',expected
+        print('expected:',expected)
         assert observed == expected
 
         # stop truncated by 1 bp should only get you the UTR for GFF, or just the start codon[s] for GTF.
         observed = sorted([i.id for i in self.G.overlapping_features(chrom='chr2L',start=7529,stop=8115, completely_within=True)])
-        print 'observed:',observed
+        print('observed:',observed)
         if self.featureclass == 'GFF':
             expected = ['five_prime_UTR_FBgn0031208:1_737']
         if self.featureclass == 'GTF':
             expected = ['start_codon:chr2L:7680-7682:+']
-        print 'expected:',expected
+        print('expected:',expected)
         assert observed == expected
 
         # and the 5'UTR, but with start truncated 1 bp, should get you nothing -- for both GFF and GTF.
         observed = sorted([i.id for i in self.G.overlapping_features(chrom='chr2L',start=7530,stop=7679, completely_within=True)])
-        print 'observed:',observed
+        print('observed:',observed)
         expected = []
-        print 'expected:',expected
+        print('expected:',expected)
         assert observed == expected
 
     def merge_features_test(self):
@@ -681,8 +681,8 @@ chr2L	protein_coding	stop_codon	9277	9279	.	+	0	gene_id "FBgn0031208"; transcrip
                     frame='.',
                     attributes='')]
 
-        print 'observed:', observed
-        print 'expected:',expected
+        print('observed:', observed)
+        print('expected:',expected)
         assert observed == expected
 
         # make sure you complain if more than one strand and ignore_strand=False
@@ -748,8 +748,8 @@ chr2L	protein_coding	stop_codon	9277	9279	.	+	0	gene_id "FBgn0031208"; transcrip
                     self.Feature(chrom='chr2L',start=8193,stop=9484, strand='+', featuretype='merged_exon'),
                    ]
 
-        print 'observed:',observed
-        print 'expected:',expected
+        print('observed:',observed)
+        print('expected:',expected)
         assert observed == expected
 
     def interfeatures_test(self):
@@ -791,16 +791,16 @@ chr2L	protein_coding	stop_codon	9277	9279	.	+	0	gene_id "FBgn0031208"; transcrip
                     strand='.',
                     frame='.',
                     attributes='')]
-        print 'observed:', observed
-        print 'expected:', expected
+        print('observed:', observed)
+        print('expected:', expected)
         assert observed == expected
 
     def execute_test(self):
         query = 'SELECT id, chrom, start, stop FROM features WHERE id = "FBgn0031208"'
         expected = [('FBgn0031208','chr2L',7529,9484)]
         observed = list(self.G.execute(query))
-        print observed
-        print expected
+        print(observed)
+        print(expected)
         assert observed == expected
 
 
@@ -811,10 +811,10 @@ chr2L	protein_coding	stop_codon	9277	9279	.	+	0	gene_id "FBgn0031208"; transcrip
         expected = """FBtr0300689	FBgn0031208	chr2L	+	7529	9484	7680	8610	2	7529,8193,	8116,9484,
 FBtr0300690	FBgn0031208	chr2L	+	7529	9484	7680	9276	3	7529,8193,8668,	8116,8589,9484,
 """
-        print 'observed:'
-        print observed
-        print 'expected:'
-        print expected
+        print('observed:')
+        print(observed)
+        print('expected:')
+        print(expected)
         assert observed == expected
 
     def test_n_isoforms(self):
@@ -822,15 +822,15 @@ FBtr0300690	FBgn0031208	chr2L	+	7529	9484	7680	9276	3	7529,8193,8668,	8116,8589,
 
     def promoter_test(self):
         # test defaults of bidirectional=True and dist=1000
-        print 'original:', self.G['FBgn0031208']
+        print('original:', self.G['FBgn0031208'])
         observed = self.G.promoter(id='FBgn0031208', direction='both')
         expected = self.Feature(chrom='chr2L', source='imputed', start=6529,stop=8529,strand='+')
         expected.featuretype = 'promoter'
-        print 'observed:'
-        print observed
-        print 'len(observed):',len(observed)
-        print 'expected:'
-        print expected
+        print('observed:')
+        print(observed)
+        print('len(observed):',len(observed))
+        print('expected:')
+        print(expected)
 
         # 1000 upstream and the TSS itself.
         assert len(observed) == 2001
@@ -841,11 +841,11 @@ FBtr0300690	FBgn0031208	chr2L	+	7529	9484	7680	9276	3	7529,8193,8668,	8116,8589,
         observed = self.G.promoter(id=self.G['FBgn0031208'], direction='both')
         expected = self.Feature(chrom='chr2L', source='imputed', start=6529,stop=8529,strand='+')
         expected.featuretype = 'promoter'
-        print 'observed:'
-        print observed
-        print 'len(observed):',len(observed)
-        print 'expected:'
-        print expected
+        print('observed:')
+        print(observed)
+        print('len(observed):',len(observed))
+        print('expected:')
+        print(expected)
 
         # 1000 upstream and the TSS itself.
         assert len(observed) == 2001
@@ -855,11 +855,11 @@ FBtr0300690	FBgn0031208	chr2L	+	7529	9484	7680	9276	3	7529,8193,8668,	8116,8589,
         # Test various kwargs
         observed = self.G.promoter(id='FBgn0031208',dist=100)
         expected = self.Feature(chrom='chr2L',start=7429,stop=7529,strand='+', featuretype='promoter', source='imputed')
-        print 'observed:'
-        print observed
-        print 'len(observed):',len(observed)
-        print 'expected:'
-        print expected
+        print('observed:')
+        print(observed)
+        print('len(observed):',len(observed))
+        print('expected:')
+        print(expected)
         assert len(observed) == 101
         assert observed == expected
 
@@ -869,11 +869,11 @@ FBtr0300690	FBgn0031208	chr2L	+	7529	9484	7680	9276	3	7529,8193,8668,	8116,8589,
         expected = self.Feature(chrom='chr2L',start=7529,stop=7629,strand='+')
         expected.featuretype = 'promoter'
         expected.source = 'imputed'
-        print 'observed:'
-        print observed
-        print 'len(observed):',len(observed)
-        print 'expected:'
-        print expected
+        print('observed:')
+        print(observed)
+        print('len(observed):',len(observed))
+        print('expected:')
+        print(expected)
         assert len(observed) == 101
         assert observed == expected
 
@@ -885,11 +885,11 @@ FBtr0300690	FBgn0031208	chr2L	+	7529	9484	7680	9276	3	7529,8193,8668,	8116,8589,
             expected = self.Feature(chrom='chr2L',start=11000,stop=11500,strand='-')
             expected.featuretype = 'promoter'
             expected.source = 'imputed'
-            print 'observed:'
-            print observed
-            print 'len(observed):',len(observed)
-            print 'expected:'
-            print expected
+            print('observed:')
+            print(observed)
+            print('len(observed):',len(observed))
+            print('expected:')
+            print(expected)
             assert len(observed) == 501
             assert observed == expected
 
@@ -930,8 +930,8 @@ FBtr0300690	FBgn0031208	chr2L	+	7529	9484	7680	9276	3	7529,8193,8668,	8116,8589,
     def coding_genes_test(self):
         observed = sorted([i.id for i in self.G.coding_genes()])
         expected = ['FBgn0031208','Fk_gene_1']
-        print 'observed:',observed
-        print 'expected:',expected
+        print('observed:',observed)
+        print('expected:',expected)
         assert observed == expected
 
     def n_exon_isoforms_test(self):
@@ -940,8 +940,8 @@ FBtr0300690	FBgn0031208	chr2L	+	7529	9484	7680	9276	3	7529,8193,8668,	8116,8589,
         exon = exons[0]
         observed = self.G.n_exon_isoforms(exon)
         expected = 2
-        print 'observed:',observed
-        print 'expected:',expected
+        print('observed:',observed)
+        print('expected:',expected)
         assert observed == expected
 
     def exons_gene_test(self):
@@ -952,8 +952,8 @@ FBtr0300690	FBgn0031208	chr2L	+	7529	9484	7680	9276	3	7529,8193,8668,	8116,8589,
         exon = exons[0]
         observed = self.G.exons_gene(exon)
         expected = 'FBgn0031208'
-        print 'observed:',observed
-        print 'expected:',expected
+        print('observed:',observed)
+        print('expected:',expected)
         assert observed == expected
 
     def teardown(self):
@@ -982,8 +982,8 @@ class TestGTFDBClass(GenericDBClass):
                     self.Feature(chrom='chr2L',start=7529,stop=7679,strand='+',featuretype='five_prime_UTR'),
                     self.Feature(chrom='chr2L',start=8611,stop=9484,strand='+',featuretype='three_prime_UTR'),
                    ]
-        print 'observed:',observed
-        print 'expected:',expected
+        print('observed:',observed)
+        print('expected:',expected)
         assert observed == expected
 
         observed = self.G.UTRs(self.G['FBtr0300690'])
@@ -991,8 +991,8 @@ class TestGTFDBClass(GenericDBClass):
                     self.Feature(chrom='chr2L',start=7529,stop=7679,strand='+',featuretype='five_prime_UTR'),
                     self.Feature(chrom='chr2L',start=9277,stop=9484,strand='+',featuretype='three_prime_UTR'),
                    ]
-        print 'observed:',observed
-        print 'expected:',expected
+        print('observed:',observed)
+        print('expected:',expected)
         assert observed == expected
 
 
@@ -1035,13 +1035,13 @@ def _attributes_modify():
     db = gffutils.FeatureDB(testdbfn_gff)
     gene_id = "FBgn0031208"
     gene_childs = list(db.children(gene_id))
-    print "old attributes: "
-    print gene_childs[0].attributes
+    print("old attributes: ")
+    print(gene_childs[0].attributes)
     assert str(gene_childs[0].attributes) == 'ID=FBtr0300689;Name=CG11023-RB;Parent=FBgn0031208;Dbxref=FlyBase_Annotation_IDs:CG11023-RB;score_text=Strongly Supported;score=11'
 
     gene_childs[0].attributes["ID"] = "Modified"
-    print "new attributes: "
-    print gene_childs[0].attributes
+    print("new attributes: ")
+    print(gene_childs[0].attributes)
     assert str(gene_childs[0].attributes) == 'ID=Modified;Name=CG11023-RB;Parent=FBgn0031208;Dbxref=FlyBase_Annotation_IDs:CG11023-RB;score_text=Strongly Supported;score=11;ID=Modified'
     ###
     ### NOTE: Would be ideal if database checked that this

--- a/gffutils/test/helpers_test.py
+++ b/gffutils/test/helpers_test.py
@@ -1,6 +1,7 @@
 import unittest
-
 from gffutils import helpers
+
+
 class Test(unittest.TestCase):
     
     def test_merge_attributes(self):
@@ -8,13 +9,13 @@ class Test(unittest.TestCase):
         Tests all possible cases of merging two dictionaries together
         """
         
-        x = {'foo' : [1], "baz" : 1, "buz" : [1], "biz" : 1, "boo" : [1]}
-        y = {'bar' : [2], "baz" : 2, "buz" : [2], "biz" : 1, "boo" : [1]}
-        test = helpers.merge_attributes(x,y)
-        true = {'foo' : [1],
-                'bar' : [2],
-                "baz" : [1,2],
-                "boo" : [1],
-                "buz" : [1,2],
-                "biz" : [1]}
+        x = {'foo': [1], "baz": 1, "buz": [1], "biz": 1, "boo": [1]}
+        y = {'bar': [2], "baz": 2, "buz": [2], "biz": 1, "boo": [1]}
+        test = helpers.merge_attributes(x, y)
+        true = {'foo': [1],
+                'bar': [2],
+                "baz": [1, 2],
+                "boo": [1],
+                "buz": [1, 2],
+                "biz": [1]}
         self.assertDictEqual(test, true) 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+six
 argh
 argcomplete
 simplejson


### PR DESCRIPTION
_This is just a proposal, not an actual pull request, it should be refined and fixed._

I added Python3 compatibility support using `six`. Few issues still remain:
1. Some circular imports still cause problems, so I added the imports into the function calls instead at the top of the module.
2. Some tests for Python3 fail (randomly) since the order of the `Attributes` is not the same. I have not yet digged deep enough to find out the cause of the error, but I suspect that the problem lies in different key ordering in Python2 and Python3 dictionary... (It seems to me that some tests rely on the key order in the dictionary)
