### PR TITLE
Change journal mode to MEMORY.

### DIFF
--- a/gffutils/create.py
+++ b/gffutils/create.py
@@ -375,7 +375,7 @@ class _DBCreator(object):
             c.executescript(
                 '''
                 PRAGMA synchronous=NORMAL;
-                PRAGMA journal_mode=WAL;
+                PRAGMA journal_mode=MEMORY;
                 ''')
 
         c.executescript(


### PR DESCRIPTION
Hi Ryan,

Thanks for your awesome work, gffutils kills it. We are distributing a gffutils database for use in bcbio-nextgen and have been running into some issues where a user would not have write access to the directory the database was in and be unable to do lookups on the database or another issue where if two processes were accessing the database simultaneously it would throw errors. We were hoping to distribute the database and use it in strictly a read-only manner and sharable across all users of the cluster.

I'm not sure but I think that WAL has some issues if you want to use the database in a distributed manner, it doesn't work well with multiple hosts accessing the same database and requires write access to the host directory for the user using the database, at least according to this URL: https://www.sqlite.org/wal.html

Swapping the pragma to MEMORY instead of WAL fixes these issues for me. We've been using MEMORY for GEMINI and it seems to work well with access from multiple hosts. What do you think about swapping the gffutils database creation to using MEMORY?
