### PR TITLE
Correcting indentation for adding transcript.

### DIFF
--- a/gffutils/contrib/plotting.py
+++ b/gffutils/contrib/plotting.py
@@ -60,7 +60,7 @@ class Gene(object):
                         d['utrs'].append(child)
                     if child.featuretype in cds:
                         d['cds'].append(child)
-            self._transcripts.append(d)
+                self._transcripts.append(d)
 
         self.tracks = []
 


### PR DESCRIPTION
Call to self._transcripts.append(d) should be inside the if clause, else we try to add transcripts with incorrect feature type and the d dictionary is not set, giving an error.
