### PR TITLE
corrected a small bug when using a function as id_spec

### DIFF
--- a/gffutils/create.py
+++ b/gffutils/create.py
@@ -135,18 +135,18 @@ class _DBCreator(object):
                     if _id.startswith('autoincrement:'):
                         return self._increment_featuretype_autoid(_id[14:])
                     return _id
-
+            else:
             # use GFF fields rather than attributes for cases like :seqid: or
             # :strand:
-            if (len(k) > 3) and (k[0] == ':') and (k[-1] == ':'):
-                # No [0] here -- only attributes key/vals are forced into
-                # lists, not standard GFF fields.
-                return getattr(f, k[1:-1])
-            else:
-                try:
-                    return f.attributes[k][0]
-                except (KeyError, IndexError):
-                    pass
+                if (len(k) > 3) and (k[0] == ':') and (k[-1] == ':'):
+                    # No [0] here -- only attributes key/vals are forced into
+                    # lists, not standard GFF fields.
+                    return getattr(f, k[1:-1])
+                else:
+                    try:
+                        return f.attributes[k][0]
+                    except (KeyError, IndexError):
+                        pass
         # If we get here, then default autoincrement
         return self._increment_featuretype_autoid(f.featuretype)
 


### PR DESCRIPTION
When a function was used as id_spec, the creation of the db would crash with "TypeError: object of type 'function' has no len()" as it would go into a series of test destined for a list type of id_specs.
