### PR TITLE
add support for very large geneomes

### DIFF
--- a/gffutils/bins.py
+++ b/gffutils/bins.py
@@ -77,7 +77,10 @@ def bins(start, stop, fmt='gff', one=True):
     # For very large coordinates, return 1 which is "somewhere on the
     # chromosome".
     if start >= MAX_CHROM_SIZE or stop >= MAX_CHROM_SIZE:
-        return 1
+        if one:
+            return 1
+        else:
+            return set([1])
 
     # Jump to highest resolution bin that will fit these coords (depending on
     # whether we have a BED or GFF-style coordinate).

--- a/gffutils/bins.py
+++ b/gffutils/bins.py
@@ -114,6 +114,13 @@ def bins(start, stop, fmt='gff', one=True):
         # larger bin size)
         start >>= NEXT_SHIFT
         stop >>= NEXT_SHIFT
+
+    # If the coords are outside ~512Mb (536870912), then we may get multiple
+    # bins due to overflow. In that case, set to the largest bin. This will result
+    # in a performance hit for features that are >512Mb from the beginning of
+    # a chromosome.
+    if one and len(bins) > 1:
+        return min(bins)
     return bins
 
 
@@ -213,6 +220,8 @@ def test():
     assert bins(-1, -1000, one=False) == set([1])
     assert bins(1, -1000, one=True) == 1
     assert bins(1, -1000, one=False) == set([1])
+
+    assert bins(536870912, 536870913, one=True) == 1
 
 if __name__ == "__main__":
     print_bin_sizes()

--- a/gffutils/interface.py
+++ b/gffutils/interface.py
@@ -604,17 +604,15 @@ class FeatureDB(object):
         # Only use bins if we have defined boundaries and completely_within is
         # True. Otherwise you can't know how far away a feature stretches
         # (which means bins are not computable ahead of time)
+        _bin_clause = ''
         if (start is not None) and (end is not None) and completely_within:
-            _bins = list(bins.bins(start, end, one=False))
-            # See issue #45
-            if len(_bins) < 900:
-                _bin_clause = ' or ' .join(['bin = ?' for _ in _bins])
-                _bin_clause = 'AND ( %s )' % _bin_clause
-                args += _bins
-            else:
-                _bin_clause = ''
-        else:
-            _bin_clause = ''
+            if start <= bins.MAX_CHROM_SIZE and end <= bins.MAX_CHROM_SIZE:
+                _bins = list(bins.bins(start, end, one=False))
+                # See issue #45
+                if len(_bins) < 900:
+                    _bin_clause = ' or ' .join(['bin = ?' for _ in _bins])
+                    _bin_clause = 'AND ( %s )' % _bin_clause
+                    args += _bins
 
         query = ' '.join([
             constants._SELECT,


### PR DESCRIPTION
This fixes #112 and #94 by handling large genomes with chromosomes larger than `2^29` bp.

Changing the binning system (specifically, changing the coordinates that each bin represents) would be a backwards-incompatible change. I'm not willing to do that just yet. Instead, if there are multiple bins we just return bin 1 which means "on the chromosome".

This will result in a performance hit when trying to do intersections with features at the ends of long chromosomes, but I'm not sure I have a better solution at the moment.