### PR TITLE
Fix unused variable error by using created id.

### DIFF
--- a/gffutils/biopython_integration.py
+++ b/gffutils/biopython_integration.py
@@ -5,7 +5,6 @@ objects.
 import six
 try:
     from Bio.SeqFeature import SeqFeature, FeatureLocation
-    from Bio import SeqIO
 except ImportError:
     import warnings
     warnings.warn("BioPython must be installed to use this module")
@@ -79,4 +78,4 @@ def from_seqfeature(s, **kwargs):
     attributes.pop('seqid', '.')
     attributes.pop('frame', '.')
     return Feature(seqid, source, featuretype, start, stop, score, strand,
-                   frame, attributes, **kwargs)
+                   frame, attributes, id=id, **kwargs)

--- a/gffutils/test/test_biopython_integration.py
+++ b/gffutils/test/test_biopython_integration.py
@@ -14,5 +14,6 @@ def test_roundtrip():
     s = bp.to_seqfeature(feature)
     assert s.location.start.position == feature.start - 1
     assert s.location.end.position == feature.stop
+    assert s.id == feature.id
     f = bp.from_seqfeature(s, dialect=dialect, keep_order=True)
     assert feature == f


### PR DESCRIPTION
This is a small PR to pass the id of the sequence feature in BioPython to the gffutils Feature. I noticed that the id was getting pulled out, but not getting passed to the Feature constructor so it was getting dropped.

https://github.com/tshauck/gffutils/blob/52a63f650ff1c7362e78b26bbf4d063dc3091b11/gffutils/biopython_integration.py#L74

Also added a test to check the ids are the same.

Thanks for writing/maintaining this package!