### PR TITLE
Fix list attributes of second param from being modified.

### DIFF
--- a/gffutils/helpers.py
+++ b/gffutils/helpers.py
@@ -318,7 +318,7 @@ def merge_attributes(attr1, attr2):
     """
 
     new_d = copy.deepcopy(attr1)
-    new_d.update(attr2)
+    new_d.update(copy.deepcopy(attr2))
 
     #all of attr2 key : values just overwrote attr1, fix it
     for k, v in new_d.items():

--- a/gffutils/test/test.py
+++ b/gffutils/test/test.py
@@ -1229,6 +1229,15 @@ def test_issue_119():
     db5 = db3.update(db4)
     assert db5._autoincrements == {'gene': 2}
 
+def test_pr_133():
+    d1 = {'a': [1]}
+    d2 = {'a': [2]}
+    d1a = {'a': [1]}
+    d2a = {'a': [2]}
+    d3 = gffutils.helpers.merge_attributes(d1, d2)
+    assert d1 == d1a, d1
+    assert d2 == d2a, d2
+
 
 if __name__ == "__main__":
     # this test case fails


### PR DESCRIPTION
`new_d.update(attr2)` does not deep copy the values from attr2. The code then later goes on to modify the values, corrupting the attribues in attr2.