### PR TITLE
Make FeatureDB._autoincrement interface the same as DBCreator._autoincrement

### DIFF
--- a/gffutils/interface.py
+++ b/gffutils/interface.py
@@ -1,3 +1,4 @@
+import collections
 import os
 import six
 import sqlite3
@@ -147,7 +148,7 @@ class FeatureDB(object):
             '''
             SELECT base, n FROM autoincrements
             ''')
-        self._autoincrements = dict(c)
+        self._autoincrements = collections.defaultdict(int, c)
 
         self.set_pragmas(pragmas)
 


### PR DESCRIPTION
This makes both instances a defaultdict.
The two instances still need more logic to reconcile divergence of their states.