### PR TITLE
Fix interfeatures merge attributes

### DIFF
--- a/gffutils/interface.py
+++ b/gffutils/interface.py
@@ -765,6 +765,7 @@ class FeatureDB(object):
                     dialect = None
             yield self._feature_returner(**fields)
             interfeature_start = f.stop
+            last_feature = f
 
     def delete(self, features, make_backup=True, **kwargs):
         """


### PR DESCRIPTION
I noticed a small problem when imputing intron features: the start and end coords were correct, but all of the intron attributes (for a given transcript) referenced either the first (sense strand) or last (antisense strand) exons.