### PR TITLE
fix for GFFs with ##FASTA section in python 3.7

### DIFF
--- a/gffutils/iterators.py
+++ b/gffutils/iterators.py
@@ -187,7 +187,10 @@ class _FeatureIterator(_BaseIterator):
         for i, feature in enumerate(self.data):
             self.current_item = feature
             self.current_item_number = i
-            yield feature
+            try:
+                yield feature
+            except StopIteration:
+                return
 
 
 class _StringIterator(_FileIterator):

--- a/gffutils/version.py
+++ b/gffutils/version.py
@@ -1,1 +1,1 @@
-version="0.9"
+version="0.9.1"

--- a/gffutils/version.py
+++ b/gffutils/version.py
@@ -1,1 +1,1 @@
-version="0.9.1"
+version="0.9"


### PR DESCRIPTION
Apparently in Python 3.7 the behavior of StopIteration changes such that gffutils=0.9 crashes with a "RuntimeError: generator raised StopIteration" exception in iterators.py whenever a GFF file is loaded that contains a ##FASTA section at the end with sequences. I wrapped the offending statement in a try/except as suggested [here](https://stackoverflow.com/questions/51700960/runtimeerror-generator-raised-stopiteration-every-time-i-try-to-run-app); that seems to fix the problem.

(This is my first pull request so sorry in advance if I'm doing something wrong!)