### PR TITLE
More issue 119 tests

### DIFF
--- a/gffutils/create.py
+++ b/gffutils/create.py
@@ -48,7 +48,7 @@ def deprecation_handler(kwargs):
 
 class _DBCreator(object):
     def __init__(self, data, dbfn, force=False, verbose=False, id_spec=None,
-                 merge_strategy='merge', checklines=10, transform=None,
+                 merge_strategy='error', checklines=10, transform=None,
                  force_dialect_check=False, from_string=False, dialect=None,
                  default_encoding='utf-8',
                  disable_infer_genes=False,


### PR DESCRIPTION
While documenting these tests I realized that while `create_db` has a default of `merge_strategy="error"`, `_DBCreator` still had a default of `"merge"`. As a result, `FeatureDB.update` would use a default of merge. The tests needed some updating to reflect this change.