### PR TITLE
Avoid deadlocks in tests under Python 3.8

### DIFF
--- a/gffutils/test/test.py
+++ b/gffutils/test/test.py
@@ -921,8 +921,11 @@ def test_tempfiles():
     # .travis.yml sets the PROCESSES env var; otherwise use all available.
     PROCESSES = int(os.environ.get("PROCESSES", multiprocessing.cpu_count()))
     pool = multiprocessing.Pool(PROCESSES)
-    n = 100
-    res = pool.map(make_db, range(n))
+    try:
+        n = 100
+        res = pool.map(make_db, range(n))
+    finally:
+        pool.close()
     assert sorted(list(res)) == list(range(n))
     filelist = os.listdir(tempdir)
     assert len(filelist) == n, len(filelist)


### PR DESCRIPTION
Looks related to: https://bugs.python.org/issue38501
See: https://bugs.debian.org/950853