### PR TITLE
Fix deprecation warning.

### DIFF
--- a/gffutils/parser.py
+++ b/gffutils/parser.py
@@ -16,7 +16,7 @@ ch.setLevel(logging.INFO)
 ch.setFormatter(formatter)
 logger.addHandler(ch)
 
-gff3_kw_pat = re.compile('\w+=')
+gff3_kw_pat = re.compile(r'\w+=')
 
 # Encoding/decoding notes
 # -----------------------


### PR DESCRIPTION
Fixes this deprecation warning:

```
gffutils/parser.py:19: DeprecationWarning: invalid escape sequence
gff3_kw_pat = re.compile('\w+=')
```