### PR TITLE
Python3 DeprecationWarning: invalid escape sequence \w

### DIFF
--- a/gffutils/parser.py
+++ b/gffutils/parser.py
@@ -16,7 +16,7 @@ ch.setLevel(logging.INFO)
 ch.setFormatter(formatter)
 logger.addHandler(ch)
 
-gff3_kw_pat = re.compile('\w+=')
+gff3_kw_pat = re.compile(r'\w+=')
 
 # Encoding/decoding notes
 # -----------------------


### PR DESCRIPTION
As instructed on https://stackoverflow.com/questions/50504500/deprecationwarning-invalid-escape-sequence-what-to-use-instead-of-d
Works for me.