### PR TITLE
Use Context Manager in FileIterator

### DIFF
--- a/gffutils/iterators.py
+++ b/gffutils/iterators.py
@@ -123,26 +123,27 @@ class _FileIterator(_BaseIterator):
 
     def _custom_iter(self):
         valid_lines = 0
-        for i, line in enumerate(self.open_function(self.data)):
-            if isinstance(line, six.binary_type):
-                line = line.decode('utf-8')
-            line = line.rstrip('\n\r')
-            self.current_item = line
-            self.current_item_number = i
+        with self.open_function(self.data) as fh:
+            for i, line in enumerate(fh):
+                if isinstance(line, six.binary_type):
+                    line = line.decode('utf-8')
+                line = line.rstrip('\n\r')
+                self.current_item = line
+                self.current_item_number = i
 
-            if line == '##FASTA' or line.startswith('>'):
-                return
+                if line == '##FASTA' or line.startswith('>'):
+                    return
 
-            if line.startswith('##'):
-                self._directive_handler(line)
-                continue
+                if line.startswith('##'):
+                    self._directive_handler(line)
+                    continue
 
-            if line.startswith(('#')) or len(line) == 0:
-                continue
+                if line.startswith(('#')) or len(line) == 0:
+                    continue
 
-            # (If we got here it should be a valid line)
-            valid_lines += 1
-            yield feature_from_line(line, dialect=self.dialect)
+                # (If we got here it should be a valid line)
+                valid_lines += 1
+                yield feature_from_line(line, dialect=self.dialect)
 
 
 class _UrlIterator(_FileIterator):


### PR DESCRIPTION
Open files inside of a context manager so that the file is properly closed when the iterator gets to the end. This suppresses warnings of the form:
```
ResourceWarning: unclosed file <_io.TextIOWrapper name='<path>' mode='r' encoding='UTF-8'>
```