### PR TITLE
Handle empty string in Quoter

### DIFF
--- a/gffutils/parser.py
+++ b/gffutils/parser.py
@@ -63,7 +63,7 @@ _to_quote += chr(127)
 # there.
 class Quoter(collections.defaultdict):
     def __missing__(self, b):
-        if b in _to_quote:
+        if b != "" and b in _to_quote:
             res = '%{:02X}'.format(ord(b))
         else:
             res = b


### PR DESCRIPTION
b = ""
b in "foo" == True which causes the following error:
```
  File "/home/ncm3/.local/lib/python3.9/site-packages/biopython_convert/__init__.py", line 118, in to_stats
    return str(gffutils.Feature(record.id, "biopython.convert", "sequence", start=1, end=len(record), attributes=attributes))
  File "/home/ncm3/.local/lib/python3.9/site-packages/gffutils/feature.py", line 230, in __str__
    return self.__unicode__()
  File "/home/ncm3/.local/lib/python3.9/site-packages/gffutils/feature.py", line 251, in __unicode__
    reconstructed_attributes = parser._reconstruct(
  File "/home/ncm3/.local/lib/python3.9/site-packages/gffutils/parser.py", line 113, in _reconstruct
    attributes[k].append(''.join([quoter[j] for j in i]))
  File "/home/ncm3/.local/lib/python3.9/site-packages/gffutils/parser.py", line 113, in <listcomp>
    attributes[k].append(''.join([quoter[j] for j in i]))
  File "/home/ncm3/.local/lib/python3.9/site-packages/gffutils/parser.py", line 67, in __missing__
    res = '%{:02X}'.format(ord(b))
TypeError: ord() expected a character, but string of length 0 found
```