### PR TITLE
Handle a bug in NCBI gtf

### DIFF
--- a/gffutils/create.py
+++ b/gffutils/create.py
@@ -784,7 +784,10 @@ class _GTFDBCreator(_DBCreator):
             relations = []
             parent = None
             grandparent = None
-            if self.transcript_key in f.attributes:
+            if (
+                self.transcript_key in f.attributes and
+                f.attributes[self.transcript_key]
+            ):
                 parent = f.attributes[self.transcript_key][0]
                 relations.append((parent, f.id, 1))
 


### PR DESCRIPTION
NCBI gtf sometimes has an empty transcript_id field, which causes an IndexError when creating a db because gffutils sees that there is a transcript_id attribute present and then tries to use it depsite it being blank. This commit adds a second check to make sure that it is not blank before accessing it to avoid this error.

Example of bad line in NCBI gtf:
```
NC_049222.1     Gnomon  gene    209085  282880  .       -       .       gene_id "ENPP1_3"; transcript_id ""; db_xref "GeneID:100856150"; db_xref "VGNC:VGNC:40374"; gbkey "Gene"; gene "ENPP1"; gene_biotype "protein_coding";
```

Stacktrace of error in gffutils caused by this line:
```
  File "/storage/hpc/group/warrenlab/users/esrbhb/mambaforge/envs/bio/lib/python3.9/site-packages/gffutils/create.py", line 1292, in create_db
    c.create()
  File "/storage/hpc/group/warrenlab/users/esrbhb/mambaforge/envs/bio/lib/python3.9/site-packages/gffutils/create.py", line 507, in create
    self._populate_from_lines(self.iterator)
  File "/storage/hpc/group/warrenlab/users/esrbhb/mambaforge/envs/bio/lib/python3.9/site-packages/gffutils/create.py", line 788, in _populate_from_lines
    parent = f.attributes[self.transcript_key][0]
IndexError: list index out of range
```