### PR TITLE
Fix bug multiple values for ID attribute are no longer permitted since v0.11

### DIFF
--- a/gffutils/interface.py
+++ b/gffutils/interface.py
@@ -963,6 +963,10 @@ class FeatureDB(object):
             # Ready to yield
             new_feature = _prep_for_yield(interfeature)
             if new_feature:
+                # concat list of ID to create uniq IDs because feature with multiple values for their ID are no longer permitted since v0.11
+                if len(new_feature.attributes["ID"]) > 1:
+                    new_id = '_'.join(new_feature.attributes["ID"])
+                    new_feature.attributes["ID"] = [new_id]
                 yield new_feature
             nfeatures = 1
 


### PR DESCRIPTION
interfeatures creates list of IDs: concat list of ID to create uniq IDs because feature with multiple values for their ID are no longer permitted since v0.11

The solution I suggest is quite brute and apply only when creating interfeatures features. Multiple IDs should not arise in other occasion. GFF specification does not allow multiple IDs, only multiple Parents. 