### PR TITLE
move strand specification to FeatureLocation in `to_seqfeature`

### DIFF
--- a/gffutils/biopython_integration.py
+++ b/gffutils/biopython_integration.py
@@ -46,10 +46,12 @@ def to_seqfeature(feature):
     return SeqFeature(
         # Convert from GFF 1-based to standard Python 0-based indexing used by
         # BioPython
-        FeatureLocation(feature.start - 1, feature.stop),
+        FeatureLocation(
+            feature.start - 1,
+            feature.stop,
+            strand=_biopython_strand[feature.strand]),
         id=feature.id,
         type=feature.featuretype,
-        strand=_biopython_strand[feature.strand],
         qualifiers=qualifiers,
     )
 


### PR DESCRIPTION
In BioPython 1.81, the `strand` property was moved from SeqFeature to FeatureLocation, and in BioPython 1.82, an accessor was included in the SeqFeature object, but the `strand` keyword arg to `SeqFeature.__init__` was not re-added (and doesn't look like it will be to me).