### PR TITLE
Add pytest 8.x compat

### DIFF
--- a/gffutils/test/feature_test.py
+++ b/gffutils/test/feature_test.py
@@ -152,10 +152,10 @@ class IsolatedTestCase(object):
     namespace or something?  Anyway, these setup/teardowns do the trick.
     """
 
-    def setup(self):
+    def setup_method(self):
         constants.always_return_list = False
 
-    def teardown(self):
+    def teardown_method(self):
         constants.always_return_list = True
 
     def test_feature_single_item(self):

--- a/gffutils/test/test_1.py
+++ b/gffutils/test/test_1.py
@@ -193,7 +193,7 @@ class BaseDB(object):
 
     orig_fn = None
 
-    def setup(self):
+    def setup_method(self):
         def gff_id_func(f):
             if "ID" in f.attributes:
                 return f.attributes["ID"][0]


### PR DESCRIPTION
Works with Pytest 7.x+

We needed this patch for Debian's development distribution where we are upgrading to Pytest 8.0.2