### PR TITLE
drop usage of Python2-era simplejson

### DIFF
--- a/gffutils/feature.py
+++ b/gffutils/feature.py
@@ -1,5 +1,5 @@
 from pyfaidx import Fasta
-import simplejson as json
+import json
 from gffutils import constants
 from gffutils import helpers
 from gffutils import parser

--- a/gffutils/helpers.py
+++ b/gffutils/helpers.py
@@ -1,7 +1,7 @@
 import copy
 import sys
 import os
-import simplejson as json
+import json
 import time
 import tempfile
 from gffutils import constants

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pyfaidx>=0.5.5.2
 argh>=0.26.2
 argcomplete>=1.9.4
-simplejson


### PR DESCRIPTION
simplejson was of backport of Python3 json module for Python2