### PR TITLE
Use recursive query to set relation levels from GFF

### DIFF
--- a/gffutils/test/test_1.py
+++ b/gffutils/test/test_1.py
@@ -961,15 +961,6 @@ def test_tempfiles():
     assert len(filelist) == 1, filelist
     assert filelist[0].endswith(".gffutils")
 
-    # ...and another one for gff. This time, make sure the suffix
-    db = gffutils.create_db(
-        gffutils.example_filename("FBgn0031208.gff"), ":memory:", _keep_tempfiles=True
-    )
-    filelist = os.listdir(tempdir)
-    assert len(filelist) == 2, filelist
-    for i in filelist:
-        assert i.endswith(".gffutils")
-
     # OK, now delete what we have so far...
     clean_tempdir()
 

--- a/gffutils/test/test_issues.py
+++ b/gffutils/test/test_issues.py
@@ -474,14 +474,14 @@ def test_issue_198():
 
 
 def test_issue_204():
-    gff="""\
+    txt = dedent("""\
     chr1 AUGUSTUS gene 68330 73621 1 - . ID=g1903;
     chr1 AUGUSTUS mRNA 68330 73621 1 - . ID=g1903.t1;Parent=g1903;
     chr1 Pfam protein_match 73372 73618 1 - . ID=g1903.t1.d1;Parent=g1903.t1;
     chr1 Pfam protein_hmm_match 73372 73618 1 - . ID=g1903.t1.d1.1;Parent=g1903.t1.d1;
-    """
+    """)
 
-    db = gffutils.create_db(gff.replace(' ', '\t'), ':memory:', from_string=True)
+    db = gffutils.create_db(txt.replace(" ", "\t"), ":memory:", from_string=True)
 
     parents1 = {
         "g1903": [],

--- a/gffutils/test/test_issues.py
+++ b/gffutils/test/test_issues.py
@@ -473,6 +473,45 @@ def test_issue_198():
     assert f.attributes["Parent"] == ["XM_001475631.1", ""]
 
 
+def test_issue_204():
+    gff="""\
+    chr1 AUGUSTUS gene 68330 73621 1 - . ID=g1903;
+    chr1 AUGUSTUS mRNA 68330 73621 1 - . ID=g1903.t1;Parent=g1903;
+    chr1 Pfam protein_match 73372 73618 1 - . ID=g1903.t1.d1;Parent=g1903.t1;
+    chr1 Pfam protein_hmm_match 73372 73618 1 - . ID=g1903.t1.d1.1;Parent=g1903.t1.d1;
+    """
+
+    db = gffutils.create_db(gff.replace(' ', '\t'), ':memory:', from_string=True)
+
+    parents1 = {
+        "g1903": [],
+        "g1903.t1": ["g1903"],
+        "g1903.t1.d1": ["g1903.t1"],
+        "g1903.t1.d1.1": ["g1903.t1.d1"],
+    }
+    parents2 = {
+        "g1903": [],
+        "g1903.t1": [],
+        "g1903.t1.d1": ["g1903"],
+        "g1903.t1.d1.1": ["g1903.t1"],
+    }
+    parents3 = {
+        "g1903": [],
+        "g1903.t1": [],
+        "g1903.t1.d1": [],
+        "g1903.t1.d1.1": ["g1903"],
+    }
+    expected_levels = [parents1, parents2, parents3]
+
+    for i, expected_level in enumerate(expected_levels):
+        for child, expected_parents in expected_level.items():
+            level = i + 1
+            observed_parents = [i.id for i in db.parents(child, level=level)]
+            print(f"observed level {str(level)} anscestors for {child}:", set(observed_parents))
+            print(f"expected level {str(level)} anscestors for {child}:", set(expected_parents))
+            assert set(observed_parents) == set(expected_parents)
+
+
 def test_issue_207():
     def _check(txt, expected_keys, dialect_trailing_semicolon):
         db = gffutils.create_db(txt.replace(" ", "\t"), ":memory:", from_string=True)


### PR DESCRIPTION
This fixes https://github.com/daler/gffutils/issues/204

Rather than using a temp file and only looking for grandchildren when updated the `relations` table, use a recursive SQL query to support a greater number of levels.

The GFF temp file is removed from `test_tempfiles()` because there is no need to create a temp file for GFF now.

Added a test based on @dariober's example.