### PR TITLE
Add context manager methods to the FeatureDB class

### DIFF
--- a/gffutils/interface.py
+++ b/gffutils/interface.py
@@ -1999,6 +1999,12 @@ class FeatureDB(object):
         for (i,) in c:
             yield i
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.conn.close()
+
     # Recycle the docs for _relation so they stay consistent between parents()
     # and children()
     children.__doc__ = children.__doc__.format(_relation_docstring=_relation.__doc__)


### PR DESCRIPTION
Hi, 

I use a python web server to serve gff data with `gffutils`.

In my application, a `FeatureDB` instance is created on every web request, and I notice that I have to `.close()` the `FeatureDB.conn` explictly, or there could be a file descriptor leak / memory leak.

This PR add context manager methods `__enter__` and `__exit__` to the FeatureDB class, so that we can manage it within a `with` statement:

```python
with sqlite3.FeatureDB("test.gff.db") as db:
    ...
```

instead of

```python
try:
    db = sqlite3.FeatureDB("test.gff.db")
    ...
finally:
    db.conn.close()
```